### PR TITLE
Add lint-k8s

### DIFF
--- a/src/gitlab-ci-lib.template.yml
+++ b/src/gitlab-ci-lib.template.yml
@@ -17,7 +17,7 @@ container_scan:
   extends: .container_scan_template
 
 lint_k8s:
-  stage: review
+  stage: test
   extends: .lint_k8s_template
 
 review:
@@ -84,9 +84,7 @@ tag_latest:
 .lint_k8s_template:
   <<: *tags
   allow_failure: false
-  stage: review
-  environment:
-    name: lint-k8s
+  stage: test
   script:
     - command lint-k8s
 

--- a/src/gitlab-ci-lib.template.yml
+++ b/src/gitlab-ci-lib.template.yml
@@ -16,6 +16,10 @@ container_scan:
   stage: test
   extends: .container_scan_template
 
+lint_k8s:
+  stage: review
+  extends: .lint_k8s_template
+
 review:
   stage: review 
   extends: .review_template
@@ -76,6 +80,15 @@ tag_latest:
   except:
     variables:
       - $CONTAINER_SCANNING_DISABLED
+
+.lint_k8s_template:
+  <<: *tags
+  allow_failure: false
+  stage: review
+  environment:
+    name: lint-k8s
+  script:
+    - command lint-k8s
 
 .review_template:
   <<: *tags


### PR DESCRIPTION
This was tested against django-echoheaders along with an updated pipline image which has it's own private PR and will need to be merged first.