### PR TITLE
Allow container scans to fail for now

### DIFF
--- a/src/gitlab-ci-lib.template.yml
+++ b/src/gitlab-ci-lib.template.yml
@@ -68,7 +68,7 @@ tag_latest:
   <<: *tags
   <<: *docker
   stage: test
-  allow_failure: false
+  allow_failure: true
   script:
     - command container_scan
   artifacts:


### PR DESCRIPTION
Temporary measure until scanning policy is in place.