### PR TITLE
disabling tls

### DIFF
--- a/src/gitlab-ci-lib.custom.template.yml
+++ b/src/gitlab-ci-lib.custom.template.yml
@@ -4,7 +4,7 @@
       - mintel
   docker_template: &docker
     services:
-      - image: docker:stable-dind
+      - name: docker:stable-dind
         entrypoint:
         - dockerd
         - --host=unix:///var/run/docker.sock

--- a/src/gitlab-ci-lib.custom.template.yml
+++ b/src/gitlab-ci-lib.custom.template.yml
@@ -7,8 +7,8 @@
       - image: docker:stable-dind
         entrypoint:
         - dockerd
-			  - --host=unix:///var/run/docker.sock
-			  - --host=tcp://0.0.0.0:2375
+        - --host=unix:///var/run/docker.sock
+        - --host=tcp://0.0.0.0:2375
     variables:
       DOCKER_DRIVER: overlay2
 

--- a/src/gitlab-ci-lib.custom.template.yml
+++ b/src/gitlab-ci-lib.custom.template.yml
@@ -4,7 +4,8 @@
       - mintel
   docker_template: &docker
     services:
-      - docker:stable-dind
+      - name: docker:stable-dind
+        entrypoint: ["dockerd"]
     variables:
       DOCKER_DRIVER: overlay2
 

--- a/src/gitlab-ci-lib.custom.template.yml
+++ b/src/gitlab-ci-lib.custom.template.yml
@@ -4,10 +4,10 @@
       - mintel
   docker_template: &docker
     services:
-      - name: docker:stable-dind
-        entrypoint: ["dockerd"]
+      - docker:stable-dind
     variables:
       DOCKER_DRIVER: overlay2
+      DOCKER_TLS_CERTDIR: ""
 
 .build_template:
   <<: *tags

--- a/src/gitlab-ci-lib.custom.template.yml
+++ b/src/gitlab-ci-lib.custom.template.yml
@@ -4,10 +4,13 @@
       - mintel
   docker_template: &docker
     services:
-      - docker:stable-dind
+      - image: docker:stable-dind
+        entrypoint:
+        - dockerd
+			  - --host=unix:///var/run/docker.sock
+			  - --host=tcp://0.0.0.0:2375
     variables:
       DOCKER_DRIVER: overlay2
-      DOCKER_TLS_CERTDIR: ""
 
 .build_template:
   <<: *tags

--- a/src/gitlab-ci-lib.template.yml
+++ b/src/gitlab-ci-lib.template.yml
@@ -79,8 +79,8 @@ loadtest:
       - image: docker:stable-dind
         entrypoint:
         - dockerd
-			  - --host=unix:///var/run/docker.sock
-			  - --host=tcp://0.0.0.0:2375
+        - --host=unix:///var/run/docker.sock
+        - --host=tcp://0.0.0.0:2375
     variables:
       DOCKER_DRIVER: overlay2
 

--- a/src/gitlab-ci-lib.template.yml
+++ b/src/gitlab-ci-lib.template.yml
@@ -76,10 +76,13 @@ loadtest:
       - mintel
   docker_template: &docker
     services:
-      - docker:stable-dind
+      - image: docker:stable-dind
+        entrypoint:
+        - dockerd
+			  - --host=unix:///var/run/docker.sock
+			  - --host=tcp://0.0.0.0:2375
     variables:
       DOCKER_DRIVER: overlay2
-      DOCKER_TLS_CERTDIR: ""
 
 .build_template:
   <<: *tags

--- a/src/gitlab-ci-lib.template.yml
+++ b/src/gitlab-ci-lib.template.yml
@@ -76,7 +76,7 @@ loadtest:
       - mintel
   docker_template: &docker
     services:
-      - image: docker:stable-dind
+      - name: docker:stable-dind
         entrypoint:
         - dockerd
         - --host=unix:///var/run/docker.sock

--- a/src/gitlab-ci-lib.template.yml
+++ b/src/gitlab-ci-lib.template.yml
@@ -76,7 +76,8 @@ loadtest:
       - mintel
   docker_template: &docker
     services:
-      - docker:stable-dind
+      - name: docker:stable-dind
+        entrypoint: ["dockerd"]
     variables:
       DOCKER_DRIVER: overlay2
 

--- a/src/gitlab-ci-lib.template.yml
+++ b/src/gitlab-ci-lib.template.yml
@@ -76,10 +76,10 @@ loadtest:
       - mintel
   docker_template: &docker
     services:
-      - name: docker:stable-dind
-        entrypoint: ["dockerd"]
+      - docker:stable-dind
     variables:
       DOCKER_DRIVER: overlay2
+      DOCKER_TLS_CERTDIR: ""
 
 .build_template:
   <<: *tags


### PR DESCRIPTION
To fix issue caused by moving `stable-dind` tag to docker v19.03